### PR TITLE
Mark DataSecretAvailable condition to true when setting dataSecretName

### DIFF
--- a/bootstrap/controllers/kthreesconfig_controller.go
+++ b/bootstrap/controllers/kthreesconfig_controller.go
@@ -183,7 +183,7 @@ func (r *KThreesConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	case configOwner.DataSecretName() != nil && (!config.Status.Ready || config.Status.DataSecretName == nil):
 		config.Status.Ready = true
 		config.Status.DataSecretName = configOwner.DataSecretName()
-		//conditions.MarkTrue(config, bootstrapv1.DataSecretAvailableCondition)
+		conditions.MarkTrue(config, bootstrapv1.DataSecretAvailableCondition)
 		return ctrl.Result{}, nil
 	// Status is ready means a config has been generated.
 	case config.Status.Ready:
@@ -594,7 +594,7 @@ func (r *KThreesConfigReconciler) storeBootstrapData(ctx context.Context, scope 
 
 	scope.Config.Status.DataSecretName = pointer.StringPtr(secret.Name)
 	scope.Config.Status.Ready = true
-	//	conditions.MarkTrue(scope.Config, bootstrapv1.DataSecretAvailableCondition)
+	conditions.MarkTrue(scope.Config, bootstrapv1.DataSecretAvailableCondition)
 	return nil
 }
 


### PR DESCRIPTION
Closes #15

I manually tried to edit the status subresource with the `kubectl edit-status` plugin and I confirm that once the DataSecretAvailable flips, then the Ready condition flips too and the cluster is fully initialized:

```console
$ clusterctl describe cluster k3-test-2
NAME                                                          READY  SEVERITY  REASON  SINCE  MESSAGE
Cluster/k3-test-2                                             True                     143m
├─ClusterInfrastructure - AWSCluster/k3-test-2                True                     5h45m
├─ControlPlane - KThreesControlPlane/k3-test-2-control-plane  True                     143m
│ └─Machine/k3-test-2-control-plane-4s42f                     True                     5h45m
└─Workers
  └─MachineDeployment/k3-test-2-md-0                          True                     141m
    └─Machine/k3-test-2-md-0-6454966fcd-mvbnt                 True                     143m
```

(I still need to actually test the code by building my branch into an image and trying it out)