### PR TITLE
Fix networking in aws k3s-template

### DIFF
--- a/samples/aws/k3s-template.yaml
+++ b/samples/aws/k3s-template.yaml
@@ -30,6 +30,12 @@ spec:
   network:
     vpc:
       availabilityZoneUsageLimit: 1
+    cni:
+      cniIngressRules:
+      - description: flannel
+        fromPort: 8472
+        protocol: udp
+        toPort: 8472
   region: ${AWS_REGION}
   sshKeyName: ${AWS_SSH_KEY_NAME}
   controlPlaneLoadBalancer:
@@ -47,6 +53,9 @@ spec:
     kind: AWSMachineTemplate
     name: ${CLUSTER_NAME}-control-plane
   kthreesConfigSpec:
+    disableComponents:
+      # not needed since we're using AWS load balancer (ccm: external)
+      - servicelb
     agentConfig:
       nodeName: "{{ ds.meta_data.local_hostname }}"
   replicas: 1


### PR DESCRIPTION
I noticed that networking wasn't working for pods scheduled on the worker node.

k3s uses flannel by default, which implements an overlay network using VXLAN, which uses an UDP port (the port number is documented in https://docs.k3s.io/installation/requirements#networking).

I also noticed that using the aws ccm is incompatible with servicelb (see #20) starting with k3s versions >=1.23.

IIUC how networking is supposed to work here, servicelb is meant as a "low tech" load balancer if you expose the node directly to the public internet. But since in the same we're setting up aws ccm, I _think_ we should also disable servicelb.

---

I tested this with this sample app:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 2 # tells deployment to run 2 pods matching the template
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - topologyKey: kubernetes.io/hostname
            labelSelector:
              matchExpressions:
              - key: app
                operator: In
                values:
                - nginx
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: shell
spec:
  selector:
    matchLabels:
      app: shell
  replicas: 2 # tells deployment to run 2 pods matching the template
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        app: shell
    spec:
      containers:
      - name: shell
        image: debian
        command: [ "/bin/bash", "-c", "--" ]
        args: [ "apt-get update; apt install curl; while true; do sleep 30; done;" ]
      terminationGracePeriodSeconds: 1
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - topologyKey: kubernetes.io/hostname
            labelSelector:
              matchExpressions:
              - key: app
                operator: In
                values:
                - shell
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
spec:
  selector:
    app: nginx
  ports:
  - port: 80
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: demo
spec:
  ingressClassName: traefik
  rules:
  - http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: nginx
            port:
              number: 80
```

it deploys two nginx and two shells on both nodes (control plane and worker)

* I manually issued requests to the `nginx` service from both shell pods and also directly to the pod ips for the two replicas.
* I verified that pods on both nodes can access the internet
* I verified that I could access my nginx demo pod from the external load balancer 

```console
$ ke --kubeconfig <(clusterctl get kubeconfig k3-test-24) get ingress -A
NAMESPACE   NAME   CLASS     HOSTS   ADDRESS                                                                   PORTS   AGE
default     demo   traefik   *       ad248e6fc6f2f4ceca6db3a90bbbc269-1341700786.us-east-1.elb.amazonaws.com   80      9s
```

